### PR TITLE
Fix: change EventTypeTruncateRequestCommand to EventTypeRequestTrunca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,9 +601,9 @@ const result = await client.execute(command)
 #### Truncate an Event Type
 
 ```typescript
-import { EventTypeTruncateRequestCommand, FlowcoreClient } from "@flowcore/sdk"
+import { EventTypeRequestTruncateCommand, FlowcoreClient } from "@flowcore/sdk"
 
-const command = new EventTypeTruncateRequestCommand({
+const command = new EventTypeRequestTruncateCommand({
   eventTypeId: "your-event-type-id",
   waitForTruncate: true  // Optional: Wait for truncation to complete (default: true)
 })


### PR DESCRIPTION
…teCommand

There is a typo in the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to reflect the correct command class name in usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->