### PR TITLE
feat: support fc_ API keys in notification client

### DIFF
--- a/src/common/notification-client.ts
+++ b/src/common/notification-client.ts
@@ -65,7 +65,7 @@ interface NotificationClientAuthOptionsBearer {
 
 interface NotificationClientAuthOptionsApiKey {
   apiKey: string
-  apiKeyId: string
+  apiKeyId?: string
 }
 
 type NotificationClientAuthOptions =
@@ -150,10 +150,12 @@ export class NotificationClient {
     } else {
       flowcoreClient = new FlowcoreClient({
         apiKey: this.authOptions.apiKey,
-        apiKeyId: this.authOptions.apiKeyId,
+        ...(this.authOptions.apiKeyId ? { apiKeyId: this.authOptions.apiKeyId } : {}),
       })
       urlParams.set("api_key", this.authOptions.apiKey)
-      urlParams.set("api_key_id", this.authOptions.apiKeyId)
+      if (this.authOptions.apiKeyId) {
+        urlParams.set("api_key_id", this.authOptions.apiKeyId)
+      }
     }
 
     const dataCore = await flowcoreClient.execute(


### PR DESCRIPTION
## Summary
- Make `apiKeyId` optional in `NotificationClientAuthOptionsApiKey`
- When `apiKeyId` is not provided (fc_ key format), only send `api_key` query param to the WebSocket endpoint
- `FlowcoreClient` already handles fc_ keys by parsing keyId from the prefix — this aligns the notification client

## Context
The `service-tenant-api` `/notifications` endpoint (commit `ab60ef4`) already supports `fc_` format API keys with just the `api_key` query parameter. The SDK notification client was still unconditionally requiring and sending `api_key_id`, causing WebSocket connections to fail for `fc_` keys.

## Changes
- `src/common/notification-client.ts`: `apiKeyId` is now optional, conditionally included in query params

## Backward Compatible
Legacy `api_key` + `api_key_id` format continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API-key authentication now supports optional API key ID, allowing users to authenticate without providing this parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->