### PR TITLE
feat!: align VirtualConfig with data-pathways v2 poll-based command queue

### DIFF
--- a/src/common/notification-client.ts
+++ b/src/common/notification-client.ts
@@ -65,7 +65,7 @@ interface NotificationClientAuthOptionsBearer {
 
 interface NotificationClientAuthOptionsApiKey {
   apiKey: string
-  apiKeyId: string
+  apiKeyId?: string
 }
 
 type NotificationClientAuthOptions =
@@ -150,10 +150,12 @@ export class NotificationClient {
     } else {
       flowcoreClient = new FlowcoreClient({
         apiKey: this.authOptions.apiKey,
-        apiKeyId: this.authOptions.apiKeyId,
+        ...(this.authOptions.apiKeyId ? { apiKeyId: this.authOptions.apiKeyId } : {}),
       })
       urlParams.set("api_key", this.authOptions.apiKey)
-      urlParams.set("api_key_id", this.authOptions.apiKeyId)
+      if (this.authOptions.apiKeyId) {
+        urlParams.set("api_key_id", this.authOptions.apiKeyId)
+      }
     }
 
     const dataCore = await flowcoreClient.execute(

--- a/src/contracts/data-pathways.ts
+++ b/src/contracts/data-pathways.ts
@@ -128,13 +128,9 @@ type TPathwayType = TOptional<TUnion<[TLiteral<"managed">, TLiteral<"virtual">]>
 const PathwayTypeSchema: TPathwayType = Type.Optional(Type.Union([Type.Literal("managed"), Type.Literal("virtual")]))
 
 type TVirtualConfig = TObject<{
-  resetUrl: TString
-  authHeaders: TOptional<TStringRecord>
   flowTypes: TOptional<TArray<TString>>
 }>
 const VirtualConfigSchema: TVirtualConfig = Type.Object({
-  resetUrl: Type.String(),
-  authHeaders: Type.Optional(Type.Record(Type.String(), Type.String())),
   flowTypes: Type.Optional(Type.Array(Type.String())),
 })
 export type VirtualConfig = Static<typeof VirtualConfigSchema>
@@ -343,27 +339,14 @@ export type DataPathwayCommandResponse = Static<typeof DataPathwayCommandRespons
 
 // ── Restarts ──
 
-type TVirtualResetResult = TObject<{
-  pathwayId: TString
-  success: TBoolean
-  httpStatus: TUnion<[TInteger, TNull]>
-}>
-const VirtualResetResultSchema: TVirtualResetResult = Type.Object({
-  pathwayId: Type.String(),
-  success: Type.Boolean(),
-  httpStatus: Type.Union([Type.Integer(), Type.Null()]),
-})
-
 export const DataPathwayRestartRequestResponseSchema: TObject<{
   restartRequestId: TString
   acceptedTargets: TArray<TString>
   skippedTargets: TArray<TString>
-  virtualResults: TOptional<TArray<TVirtualResetResult>>
 }> = Type.Object({
   restartRequestId: Type.String(),
   acceptedTargets: Type.Array(Type.String()),
   skippedTargets: Type.Array(Type.String()),
-  virtualResults: Type.Optional(Type.Array(VirtualResetResultSchema)),
 })
 export type DataPathwayRestartRequestResponse = Static<typeof DataPathwayRestartRequestResponseSchema>
 

--- a/test/tests/commands/data-pathways.test.ts
+++ b/test/tests/commands/data-pathways.test.ts
@@ -68,8 +68,6 @@ describe("DataPathways", () => {
         sizeClass: "small",
         type: "virtual",
         virtualConfig: {
-          resetUrl: "https://example.com/reset",
-          authHeaders: { "x-secret": "abc" },
           flowTypes: ["pathway.0", "restart.0"],
         },
       })
@@ -83,8 +81,6 @@ describe("DataPathways", () => {
         sizeClass: "small",
         type: "virtual",
         virtualConfig: {
-          resetUrl: "https://example.com/reset",
-          authHeaders: { "x-secret": "abc" },
           flowTypes: ["pathway.0", "restart.0"],
         },
       }),
@@ -105,7 +101,6 @@ describe("DataPathways", () => {
       version: 1,
       labels: {},
       virtualConfig: {
-        resetUrl: "https://example.com/reset",
         flowTypes: ["pathway.0"],
       },
       createdAt: "2025-01-01T00:00:00Z",
@@ -480,16 +475,13 @@ describe("DataPathways", () => {
     assertEquals(result, response)
   })
 
-  it("should request a restart with virtual results", async () => {
+  it("should request a restart targeting virtual pathway", async () => {
     const restartRequestId = crypto.randomUUID()
     const virtualPathwayId = crypto.randomUUID()
     const response = {
       restartRequestId,
       acceptedTargets: [virtualPathwayId],
       skippedTargets: [],
-      virtualResults: [
-        { pathwayId: virtualPathwayId, success: true, httpStatus: 200 },
-      ],
     }
 
     base.post("/api/v1/restarts/request")


### PR DESCRIPTION
## Summary

- Remove `resetUrl` and `authHeaders` from `VirtualConfig` type (only `flowTypes` remains)
- Remove `VirtualResetResult` type entirely
- Remove `virtualResults` field from `DataPathwayRestartRequestResponse`
- Update tests to match

Aligns SDK with data-pathways v2.0.0 which replaced push-based HTTP callback resets with a poll-based command queue. The CP no longer accepts `resetUrl`/`authHeaders` in virtual pathway config and no longer returns `virtualResults` in restart responses.

## Test plan

- [ ] `deno check src/mod.ts` passes
- [ ] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API key authentication now works without requiring an API key ID parameter.
  * Simplified virtual pathway configuration by removing reset URL and authentication header requirements.
  * Streamlined data pathway restart response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->