### PR TITLE
feat(iam): add PolicyValidateCommand for /api/v1/policies/validate

### DIFF
--- a/src/commands/iam/policies/validate-policy.ts
+++ b/src/commands/iam/policies/validate-policy.ts
@@ -1,0 +1,106 @@
+// src/commands/iam/policies/validate-policy.ts
+import { Command } from "../../../common/command.ts"
+import { parseResponseHelper } from "../../../utils/parse-response-helper.ts"
+import { type Static, type TLiteral, type TObject, Type } from "@sinclair/typebox"
+
+/**
+ * The schema for a successful policy validation response.
+ *
+ * Returned by `POST /api/v1/policies/validate` when the submitted policy
+ * payload passes every rule the create and patch paths enforce. Invalid
+ * payloads are surfaced as 4xx errors (422 for format / tenant boundary /
+ * UUID violations, 404 when the organization is not found) and are not
+ * represented in this schema.
+ */
+export const PolicyValidateResponseSchema: TObject<{
+  valid: TLiteral<true>
+}> = Type.Object({
+  valid: Type.Literal(true),
+})
+
+/**
+ * The Policy Validate response type
+ */
+export type PolicyValidateResponse = Static<typeof PolicyValidateResponseSchema>
+
+/**
+ * The input for the policy validate command.
+ *
+ * Mirrors the service's `validatePolicyBody` DTO: only the fields that are
+ * actually validated are required. The command is a dry-run of the same
+ * helpers used by `PolicyCreateCommand` and `PolicyUpdateCommand`, so a
+ * successful response guarantees the payload would also be accepted by
+ * those commands.
+ */
+export interface PolicyValidateInput {
+  /** The organization that would own the policy — used to enforce the tenant boundary on policyDocuments resources */
+  organizationId: string
+  /** The policy documents to validate */
+  policyDocuments: Array<{
+    /** The optional statement id */
+    statementId?: string
+    /** The resource for this statement */
+    resource: string
+    /** The actions for this statement */
+    action: string | string[]
+  }>
+  /** The optional principal role FRN (cross-tenant is intentionally permitted here) */
+  principal?: string
+}
+
+/**
+ * Dry-run validate a prospective policy payload.
+ *
+ * Calls `POST /api/v1/policies/validate`, which runs the same
+ * validation helpers as `POST /api/v1/policies/` and
+ * `PATCH /api/v1/policies/:id`. A successful response means the same
+ * payload would be accepted by the create/update commands. Useful for
+ * giving immediate feedback in UIs, CLIs, and SDK consumers before any
+ * write actually happens.
+ */
+export class PolicyValidateCommand extends Command<PolicyValidateInput, PolicyValidateResponse> {
+  /**
+   * Whether the command should retry on failure.
+   *
+   * Disabled because a 422 here indicates an invalid payload — retrying
+   * would just re-submit the same bad data.
+   */
+  protected override retryOnFailure = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "POST"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://iam.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return "/api/v1/policies/validate"
+  }
+
+  /**
+   * Get the body
+   */
+  protected override getBody(): Record<string, unknown> {
+    return {
+      ...this.input,
+    }
+  }
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): PolicyValidateResponse {
+    return parseResponseHelper(PolicyValidateResponseSchema, rawResponse)
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -113,6 +113,7 @@ export * from "./iam/permissions/get-user-permissions.ts"
 
 export * from "./iam/policies/create-policy.ts"
 export * from "./iam/policies/get-policy.ts"
+export * from "./iam/policies/validate-policy.ts"
 export * from "./iam/policies/id/archive-policy.ts"
 export * from "./iam/policies/id/get-policy.ts"
 export * from "./iam/policies/id/update-policy.ts"

--- a/test/tests/commands/iam/policies-validate.test.ts
+++ b/test/tests/commands/iam/policies-validate.test.ts
@@ -1,0 +1,192 @@
+import { assertEquals, assertRejects } from "@std/assert"
+import { afterAll, describe, it } from "@std/testing/bdd"
+import { FlowcoreClient } from "../../../../src/mod.ts"
+import { PolicyValidateCommand } from "../../../../src/commands/iam/policies/validate-policy.ts"
+import { FetchMocker } from "../../../fixtures/fetch.fixture.ts"
+
+describe("PolicyValidateCommand", () => {
+  const fetchMocker = new FetchMocker()
+  const flowcoreClient = new FlowcoreClient({ getBearerToken: () => "BEARER_TOKEN" })
+  const fetchMockerBuilder = fetchMocker.mock("https://iam.api.flowcore.io")
+
+  afterAll(() => {
+    fetchMocker.restore()
+  })
+
+  it("should return { valid: true } on a well-formed payload", async () => {
+    // arrange
+    const organizationId = crypto.randomUUID()
+    const input = {
+      organizationId,
+      policyDocuments: [
+        {
+          statementId: "stmt1",
+          resource: "frn::my-tenant:*",
+          action: ["read", "write"],
+        },
+      ],
+    }
+
+    fetchMockerBuilder.post("/api/v1/policies/validate")
+      .matchBody(input)
+      .matchHeaders({
+        "authorization": "Bearer BEARER_TOKEN",
+        "content-type": "application/json",
+      })
+      .respondWith(200, { valid: true })
+
+    // act
+    const command = new PolicyValidateCommand(input)
+    const response = await flowcoreClient.execute(command)
+
+    // assert
+    assertEquals(response.valid, true)
+  })
+
+  it("should forward an optional cross-tenant principal verbatim", async () => {
+    // arrange
+    const organizationId = crypto.randomUUID()
+    const input = {
+      organizationId,
+      policyDocuments: [
+        {
+          statementId: "1",
+          resource: "frn::my-tenant:event-type/b61e0fb1-3bf2-470e-97b6-3aeefb38b1be",
+          action: "read",
+        },
+      ],
+      principal: "frn::other-tenant:role/ddbcd838-7b05-4868-96ae-7bdc9a05067c",
+    }
+
+    fetchMockerBuilder.post("/api/v1/policies/validate")
+      .matchBody(input)
+      .respondWith(200, { valid: true })
+
+    // act
+    const command = new PolicyValidateCommand(input)
+    const response = await flowcoreClient.execute(command)
+
+    // assert
+    assertEquals(response.valid, true)
+  })
+
+  it("should accept the bare '*' wildcard resource", async () => {
+    // arrange
+    const organizationId = crypto.randomUUID()
+    const input = {
+      organizationId,
+      policyDocuments: [
+        {
+          statementId: "1",
+          resource: "*",
+          action: "*",
+        },
+      ],
+    }
+
+    fetchMockerBuilder.post("/api/v1/policies/validate")
+      .matchBody(input)
+      .respondWith(200, { valid: true })
+
+    // act
+    const command = new PolicyValidateCommand(input)
+    const response = await flowcoreClient.execute(command)
+
+    // assert
+    assertEquals(response.valid, true)
+  })
+
+  it("should reject a payload whose resource id is not a UUID (422)", async () => {
+    // arrange
+    const organizationId = crypto.randomUUID()
+    const input = {
+      organizationId,
+      policyDocuments: [
+        {
+          statementId: "1",
+          resource: "frn::my-tenant:role/not-a-uuid",
+          action: "read",
+        },
+      ],
+    }
+
+    fetchMockerBuilder.post("/api/v1/policies/validate")
+      .matchBody(input)
+      .respondWith(422, {
+        code: "UNPROCESSABLE_CONTENT",
+        message:
+          'Invalid policy resource FRN "frn::my-tenant:role/not-a-uuid": resource id "not-a-uuid" must be a UUID',
+        status: 422,
+      })
+
+    // act & assert
+    const command = new PolicyValidateCommand(input)
+    await assertRejects(
+      () => flowcoreClient.execute(command),
+      Error,
+      "PolicyValidateCommand failed with 422:",
+    )
+  })
+
+  it("should reject a cross-tenant resource FRN (422)", async () => {
+    // arrange
+    const organizationId = crypto.randomUUID()
+    const input = {
+      organizationId,
+      policyDocuments: [
+        {
+          statementId: "1",
+          resource: "frn::other-tenant:*",
+          action: "*",
+        },
+      ],
+    }
+
+    fetchMockerBuilder.post("/api/v1/policies/validate")
+      .matchBody(input)
+      .respondWith(422, {
+        code: "UNPROCESSABLE_CONTENT",
+        message:
+          'Invalid policy resource FRN "frn::other-tenant:*": tenant "other-tenant" does not match the policy\'s tenant "my-tenant"',
+        status: 422,
+      })
+
+    // act & assert
+    const command = new PolicyValidateCommand(input)
+    await assertRejects(
+      () => flowcoreClient.execute(command),
+      Error,
+      "PolicyValidateCommand failed with 422:",
+    )
+  })
+
+  it("should surface a 404 when the organization does not exist", async () => {
+    // arrange
+    const input = {
+      organizationId: "00000000-0000-0000-0000-000000000000",
+      policyDocuments: [
+        {
+          statementId: "1",
+          resource: "*",
+          action: "read",
+        },
+      ],
+    }
+
+    fetchMockerBuilder.post("/api/v1/policies/validate")
+      .matchBody(input)
+      .respondWith(404, {
+        code: "NOT_FOUND",
+        message: "Organization not found 00000000-0000-0000-0000-000000000000",
+        status: 404,
+      })
+
+    // act & assert
+    const command = new PolicyValidateCommand(input)
+    await assertRejects(
+      () => flowcoreClient.execute(command),
+      Error,
+      "PolicyValidateCommand failed with 404:",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `PolicyValidateCommand` mirroring the new dry-run validation endpoint landed in flowcore-io/service-iam-service#78.
- Clients can pre-validate a policy payload before submitting it to `PolicyCreateCommand` / `PolicyUpdateCommand` — a `{ valid: true }` response guarantees the create path would also accept it.
- No changes to any other IAM command. Audited policies / roles / associations / permissions / validate / tenant-iam-audit and confirmed their shapes still match the current service.

## Why

The service now runs `validatePolicyDocuments` and `validatePolicyPrincipal` on create, patch, and a new standalone `POST /api/v1/policies/validate` endpoint. The helpers enforce FRN format, UUID resource ids, role-type principal ids, and (as of the same PR) a cross-tenant boundary check that closes a confirmed exploited vulnerability. The SDK needed a matching command so consumers (UIs, CLIs, agents) can dry-run a payload without touching real policy state.

## Shape

```ts
new PolicyValidateCommand({
  organizationId: "<uuid>",
  policyDocuments: [
    { statementId: "1", resource: "frn::my-tenant:*", action: "read" },
  ],
  principal: "frn::other-tenant:role/<uuid>", // optional, cross-tenant allowed
})
// → { valid: true } on 200, throws on 4xx
```

- `retryOnFailure = false` (422 is a client error, same as create).
- Request body is the input spread verbatim.
- Response schema is `{ valid: Type.Literal(true) }`.

## Test plan
- [x] Happy path with wildcard resource → 200
- [x] Cross-tenant principal forwarded untouched → 200
- [x] Bare `*` wildcard resource → 200
- [x] Non-UUID resource id → 422 rejected
- [x] Cross-tenant resource FRN → 422 rejected
- [x] Missing organization → 404 rejected
- [x] `deno test -A` — 21 suites / 211 steps passing
- [x] `deno fmt --check` — 228 files clean
- [x] `deno lint` — clean (pre-existing warnings in untracked `test/debug/` are unrelated)
- [x] `deno task build:npm` — dnt builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IAM policy validation command to validate policy documents with resource, action, and optional principal information
  * Integrates with IAM API endpoint for real-time policy validation

* **Tests**
  * Added comprehensive test suite covering successful validation and error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->