### PR TITLE
fix(ci): replace sergeysova/jq-action@v2 with inline jq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,8 @@ jobs:
           token: ${{ secrets.FLOWCORE_MACHINE_GITHUB_TOKEN }}
           submodules: true
       - name: Extract version from deno.json
-        uses: sergeysova/jq-action@v2
         id: version
-        with:
-          cmd: "jq .version deno.json -r"
+        run: echo "value=$(jq -r .version deno.json)" >> "$GITHUB_OUTPUT"
       - name: Show my version
         run: 'echo "version ${{ steps.version.outputs.value }}"'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,10 +18,8 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Extract package name from deno.json
-        uses: sergeysova/jq-action@v2
         id: package
-        with:
-          cmd: "jq .name deno.json -r"
+        run: echo "value=$(jq -r .name deno.json)" >> "$GITHUB_OUTPUT"
       - name: Setup Deno2 environment
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,10 +21,8 @@ jobs:
           token: ${{ secrets.FLOWCORE_MACHINE_GITHUB_TOKEN }}
           submodules: true
       - name: Extract version from deno.json
-        uses: sergeysova/jq-action@v2
         id: version
-        with:
-          cmd: "jq .version deno.json -r"
+        run: echo "value=$(jq -r .version deno.json)" >> "$GITHUB_OUTPUT"
 
       - name: Show my version
         run: 'echo "version ${{ steps.version.outputs.value }}"'


### PR DESCRIPTION
## Summary

- `sergeysova/jq-action@v2` uses `alpine:3.11` as its Docker base, and the Alpine 3.11 mirrors started returning network errors between 2026-04-14 and 2026-04-15, breaking every workflow run that used this action.
- All three workflows (`build.yml`, `validate.yml`, `release-please.yml`) use the action only to read one field out of `deno.json`. Replace it with a plain `jq` call captured into `GITHUB_OUTPUT`. `jq` is available by default on the blacksmith-4vcpu-ubuntu-2204 runners, so no extra setup.
- This unblocks the release PR #210 (v3.1.0 for the new `PolicyValidateCommand`) which is currently failing its Test workflow on the same broken step.

## Test plan
- [ ] CI validate workflow green on this branch
- [ ] After merge, release-please refreshes PR #210 and its Test workflow passes
- [ ] v3.1.0 publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)