### PR TITLE
feat: add tenant-store command coverage

### DIFF
--- a/src/commands/api-key/api-key.fetch.ts
+++ b/src/commands/api-key/api-key.fetch.ts
@@ -1,0 +1,66 @@
+import { Command } from "../../common/command.ts"
+import type { ClientError } from "../../exceptions/client-error.ts"
+import { NotFoundException } from "../../exceptions/not-found.ts"
+import { type ApiKey, ApiKeySchema } from "../../contracts/api-key.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the api key fetch command
+ */
+export interface ApiKeyFetchInput {
+  /** The api key id */
+  apiKeyId: string
+}
+
+/**
+ * Fetch an api key
+ */
+export class ApiKeyFetchCommand extends Command<ApiKeyFetchInput, ApiKey> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "GET"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/api-keys/${this.input.apiKeyId}`
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ApiKey {
+    return parseResponseHelper(ApiKeySchema, rawResponse)
+  }
+
+  /**
+   * Handle the client error
+   */
+  protected override handleClientError(error: ClientError): void {
+    if (error.status === 404) {
+      throw new NotFoundException("ApiKey", { id: this.input.apiKeyId })
+    }
+    throw error
+  }
+}

--- a/src/commands/api-key/api-key.validate-with-tenant-id.ts
+++ b/src/commands/api-key/api-key.validate-with-tenant-id.ts
@@ -1,0 +1,51 @@
+import { Command } from "../../common/command.ts"
+import { type ApiKeyValidation, ApiKeyValidationSchema } from "../../contracts/api-key.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the api key validate with tenant id command
+ */
+export interface ApiKeyValidateWithTenantIdInput {
+  /** The api key to validate */
+  apiKey: string
+  /** The tenant id */
+  tenantId: string
+}
+
+/**
+ * Validate an api key with tenant id
+ */
+export class ApiKeyValidateWithTenantIdCommand extends Command<ApiKeyValidateWithTenantIdInput, ApiKeyValidation> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "POST"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return "/api/v1/api-keys/validate-with-tenant-id"
+  }
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ApiKeyValidation {
+    return parseResponseHelper(ApiKeyValidationSchema, rawResponse)
+  }
+}

--- a/src/commands/api-key/api-key.validate.ts
+++ b/src/commands/api-key/api-key.validate.ts
@@ -1,0 +1,49 @@
+import { Command } from "../../common/command.ts"
+import { type ApiKeyValidation, ApiKeyValidationSchema } from "../../contracts/api-key.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the api key validate command
+ */
+export interface ApiKeyValidateInput {
+  /** The api key to validate */
+  apiKey: string
+}
+
+/**
+ * Validate an api key
+ */
+export class ApiKeyValidateCommand extends Command<ApiKeyValidateInput, ApiKeyValidation> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "POST"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return "/api/v1/api-keys/validate"
+  }
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ApiKeyValidation {
+    return parseResponseHelper(ApiKeyValidationSchema, rawResponse)
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,20 +17,33 @@ export * from "./adapter/reset-adapter.ts"
 
 // Api Key
 export * from "./api-key/api-key.create.ts"
+export * from "./api-key/api-key.fetch.ts"
 export * from "./api-key/api-key.edit.ts"
 export * from "./api-key/api-key.delete.ts"
 export * from "./api-key/api-key.list.ts"
+export * from "./api-key/api-key.validate.ts"
+export * from "./api-key/api-key.validate-with-tenant-id.ts"
 
 // Secret
 export * from "./secret/secret.create.ts"
 export * from "./secret/secret.delete.ts"
 export * from "./secret/secret.edit.ts"
+export * from "./secret/secret.fetch.ts"
 export * from "./secret/secret.list.ts"
+
+// Service Account
+export * from "./service-account/service-account.create.ts"
+export * from "./service-account/service-account.delete.ts"
+export * from "./service-account/service-account.edit.ts"
+export * from "./service-account/service-account.fetch.ts"
+export * from "./service-account/service-account.list.ts"
+export * from "./service-account/service-account.rotate-secret.ts"
 
 // Variable
 export * from "./variable/variable.create.ts"
 export * from "./variable/variable.delete.ts"
 export * from "./variable/variable.edit.ts"
+export * from "./variable/variable.fetch.ts"
 export * from "./variable/variable.list.ts"
 
 // Data Core

--- a/src/commands/secret/secret.fetch.ts
+++ b/src/commands/secret/secret.fetch.ts
@@ -1,0 +1,68 @@
+import { Command } from "../../common/command.ts"
+import type { ClientError } from "../../exceptions/client-error.ts"
+import { NotFoundException } from "../../exceptions/not-found.ts"
+import { type Secret, SecretSchema } from "../../contracts/secret.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the secret fetch command
+ */
+export interface SecretFetchInput {
+  /** The tenant id */
+  tenantId: string
+  /** The secret key */
+  key: string
+}
+
+/**
+ * Fetch a secret
+ */
+export class SecretFetchCommand extends Command<SecretFetchInput, Secret> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "GET"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/tenants/${this.input.tenantId}/secrets/${this.input.key}`
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): Secret {
+    return parseResponseHelper(SecretSchema, rawResponse)
+  }
+
+  /**
+   * Handle the client error
+   */
+  protected override handleClientError(error: ClientError): void {
+    if (error.status === 404) {
+      throw new NotFoundException("Secret", { tenantId: this.input.tenantId, key: this.input.key })
+    }
+    throw error
+  }
+}

--- a/src/commands/service-account/service-account.create.ts
+++ b/src/commands/service-account/service-account.create.ts
@@ -1,0 +1,60 @@
+import { Command } from "../../common/command.ts"
+import { type ServiceAccountWithSecret, ServiceAccountWithSecretSchema } from "../../contracts/service-account.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the service account create command
+ */
+export interface ServiceAccountCreateInput {
+  /** The tenant id */
+  tenantId: string
+  /** The name of the service account */
+  name: string
+  /** The description of the service account */
+  description?: string
+  /** Whether the service account should be admin */
+  isAdmin?: boolean
+}
+
+/**
+ * Create a service account
+ */
+export class ServiceAccountCreateCommand extends Command<ServiceAccountCreateInput, ServiceAccountWithSecret> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "POST"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return "/api/v1/service-accounts"
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ServiceAccountWithSecret {
+    return parseResponseHelper(ServiceAccountWithSecretSchema, rawResponse)
+  }
+}

--- a/src/commands/service-account/service-account.delete.ts
+++ b/src/commands/service-account/service-account.delete.ts
@@ -1,0 +1,59 @@
+import { Command } from "../../common/command.ts"
+
+/**
+ * The input for the service account delete command
+ */
+export interface ServiceAccountDeleteInput {
+  /** The service account id */
+  serviceAccountId: string
+}
+
+/**
+ * Delete a service account
+ */
+export class ServiceAccountDeleteCommand extends Command<ServiceAccountDeleteInput, boolean> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "DELETE"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/service-accounts/${this.input.serviceAccountId}`
+  }
+
+  /**
+   * Get the body
+   */
+  protected override getBody(): undefined {
+    return undefined
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(): boolean {
+    return true
+  }
+}

--- a/src/commands/service-account/service-account.edit.ts
+++ b/src/commands/service-account/service-account.edit.ts
@@ -1,0 +1,68 @@
+import { Command } from "../../common/command.ts"
+import { type ServiceAccount, ServiceAccountSchema } from "../../contracts/service-account.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the service account edit command
+ */
+export interface ServiceAccountEditInput {
+  /** The service account id */
+  serviceAccountId: string
+  /** The description of the service account */
+  description?: string
+  /** Whether the service account is enabled */
+  enabled?: boolean
+}
+
+/**
+ * Edit a service account
+ */
+export class ServiceAccountEditCommand extends Command<ServiceAccountEditInput, ServiceAccount> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "PATCH"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/service-accounts/${this.input.serviceAccountId}`
+  }
+
+  /**
+   * Get the body
+   */
+  protected override getBody(): Record<string, unknown> {
+    return {
+      ...(this.input.description !== undefined ? { description: this.input.description } : {}),
+      ...(this.input.enabled !== undefined ? { enabled: this.input.enabled } : {}),
+    }
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ServiceAccount {
+    return parseResponseHelper(ServiceAccountSchema, rawResponse)
+  }
+}

--- a/src/commands/service-account/service-account.fetch.ts
+++ b/src/commands/service-account/service-account.fetch.ts
@@ -1,0 +1,66 @@
+import { Command } from "../../common/command.ts"
+import type { ClientError } from "../../exceptions/client-error.ts"
+import { NotFoundException } from "../../exceptions/not-found.ts"
+import { type ServiceAccount, ServiceAccountSchema } from "../../contracts/service-account.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the service account fetch command
+ */
+export interface ServiceAccountFetchInput {
+  /** The service account id */
+  serviceAccountId: string
+}
+
+/**
+ * Fetch a service account
+ */
+export class ServiceAccountFetchCommand extends Command<ServiceAccountFetchInput, ServiceAccount> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "GET"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/service-accounts/${this.input.serviceAccountId}`
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ServiceAccount {
+    return parseResponseHelper(ServiceAccountSchema, rawResponse)
+  }
+
+  /**
+   * Handle the client error
+   */
+  protected override handleClientError(error: ClientError): void {
+    if (error.status === 404) {
+      throw new NotFoundException("ServiceAccount", { id: this.input.serviceAccountId })
+    }
+    throw error
+  }
+}

--- a/src/commands/service-account/service-account.list.ts
+++ b/src/commands/service-account/service-account.list.ts
@@ -1,0 +1,58 @@
+import { Type } from "@sinclair/typebox"
+import { Command } from "../../common/command.ts"
+import { type ServiceAccount, ServiceAccountSchema } from "../../contracts/service-account.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the service account list command
+ */
+export interface ServiceAccountListInput {
+  /** The tenant id */
+  tenantId: string
+}
+
+/**
+ * List service accounts
+ */
+export class ServiceAccountListCommand extends Command<ServiceAccountListInput, ServiceAccount[]> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "GET"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    const queryParams = new URLSearchParams({
+      tenantId: this.input.tenantId,
+    })
+    return `/api/v1/service-accounts?${queryParams.toString()}`
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ServiceAccount[] {
+    return parseResponseHelper(Type.Array(ServiceAccountSchema), rawResponse)
+  }
+}

--- a/src/commands/service-account/service-account.rotate-secret.ts
+++ b/src/commands/service-account/service-account.rotate-secret.ts
@@ -1,0 +1,65 @@
+import { Command } from "../../common/command.ts"
+import {
+  type ServiceAccountSecretRotation,
+  ServiceAccountSecretRotationSchema,
+} from "../../contracts/service-account.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the service account rotate secret command
+ */
+export interface ServiceAccountRotateSecretInput {
+  /** The service account id */
+  serviceAccountId: string
+}
+
+/**
+ * Rotate a service account secret
+ */
+export class ServiceAccountRotateSecretCommand
+  extends Command<ServiceAccountRotateSecretInput, ServiceAccountSecretRotation> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "POST"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/service-accounts/${this.input.serviceAccountId}/rotate-secret`
+  }
+
+  /**
+   * Get the body
+   */
+  protected override getBody(): undefined {
+    return undefined
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): ServiceAccountSecretRotation {
+    return parseResponseHelper(ServiceAccountSecretRotationSchema, rawResponse)
+  }
+}

--- a/src/commands/variable/variable.fetch.ts
+++ b/src/commands/variable/variable.fetch.ts
@@ -1,0 +1,68 @@
+import { Command } from "../../common/command.ts"
+import type { ClientError } from "../../exceptions/client-error.ts"
+import { NotFoundException } from "../../exceptions/not-found.ts"
+import { type Variable, VariableSchema } from "../../contracts/variable.ts"
+import { parseResponseHelper } from "../../utils/parse-response-helper.ts"
+
+/**
+ * The input for the variable fetch command
+ */
+export interface VariableFetchInput {
+  /** The tenant id */
+  tenantId: string
+  /** The variable key */
+  key: string
+}
+
+/**
+ * Fetch a variable
+ */
+export class VariableFetchCommand extends Command<VariableFetchInput, Variable> {
+  /**
+   * Whether the command should retry on failure
+   */
+  protected override retryOnFailure: boolean = false
+
+  /**
+   * Get the method
+   */
+  protected override getMethod(): string {
+    return "GET"
+  }
+
+  /**
+   * Get the base url
+   */
+  protected override getBaseUrl(): string {
+    return "https://tenant-store.api.flowcore.io"
+  }
+
+  /**
+   * Get the path
+   */
+  protected override getPath(): string {
+    return `/api/v1/tenants/${this.input.tenantId}/variables/${this.input.key}`
+  }
+
+  /**
+   * The allowed modes for the command
+   */
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+
+  /**
+   * Parse the response
+   */
+  protected override parseResponse(rawResponse: unknown): Variable {
+    return parseResponseHelper(VariableSchema, rawResponse)
+  }
+
+  /**
+   * Handle the client error
+   */
+  protected override handleClientError(error: ClientError): void {
+    if (error.status === 404) {
+      throw new NotFoundException("Variable", { tenantId: this.input.tenantId, key: this.input.key })
+    }
+    throw error
+  }
+}

--- a/src/contracts/api-key.ts
+++ b/src/contracts/api-key.ts
@@ -1,4 +1,13 @@
-import { type Static, type TNull, type TObject, type TString, type TUnion, Type } from "@sinclair/typebox"
+import {
+  type Static,
+  type TBoolean,
+  type TNull,
+  type TObject,
+  type TOptional,
+  type TString,
+  type TUnion,
+  Type,
+} from "@sinclair/typebox"
 
 /**
  * The schema for an api key
@@ -53,3 +62,21 @@ export const ApiKeyWithValueSchema: TObject<{
  * The type for an api key with value
  */
 export type ApiKeyWithValue = Static<typeof ApiKeyWithValueSchema>
+
+/**
+ * The schema for an api key validation response
+ */
+export const ApiKeyValidationSchema: TObject<{
+  valid: TBoolean
+  apiKeyId: TOptional<TString>
+  tenantId: TOptional<TString>
+}> = Type.Object({
+  valid: Type.Boolean(),
+  apiKeyId: Type.Optional(Type.String()),
+  tenantId: Type.Optional(Type.String()),
+})
+
+/**
+ * The type for an api key validation response
+ */
+export type ApiKeyValidation = Static<typeof ApiKeyValidationSchema>

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,5 +1,6 @@
 export * from "./ai-agent-coordinator-stream.ts"
 export * from "./ai-agent-coordinator.ts"
+export type { ApiKey, ApiKeyValidation, ApiKeyWithValue } from "./api-key.ts"
 export type { DataCore } from "./data-core.ts"
 export type {
   EventType,
@@ -13,7 +14,10 @@ export type {
 } from "./event-type.ts"
 export type { FlowType } from "./flow-type.ts"
 export type { FlowcoreEvent, IngestEventInput } from "./event.ts"
+export type { Secret } from "./secret.ts"
+export type { ServiceAccount, ServiceAccountSecretRotation, ServiceAccountWithSecret } from "./service-account.ts"
 export type { Tenant, TenantInstance, TenantPreview } from "./tenant.ts"
+export type { Variable } from "./variable.ts"
 export type { Permission } from "./permission.ts"
 export type {
   LegacyScenario,

--- a/src/contracts/service-account.ts
+++ b/src/contracts/service-account.ts
@@ -1,0 +1,97 @@
+import {
+  type Static,
+  type TBoolean,
+  type TNull,
+  type TObject,
+  type TString,
+  type TUnion,
+  Type,
+} from "@sinclair/typebox"
+
+/**
+ * The schema for a service account
+ */
+export const ServiceAccountSchema: TObject<{
+  id: TString
+  tenantId: TString
+  name: TString
+  description: TString
+  linkedUserId: TString
+  clientId: TString
+  isAdmin: TBoolean
+  enabled: TBoolean
+  createdAt: TString
+  updatedAt: TUnion<[TString, TNull]>
+  lastRotatedAt: TUnion<[TString, TNull]>
+}> = Type.Object({
+  id: Type.String(),
+  tenantId: Type.String(),
+  name: Type.String(),
+  description: Type.String(),
+  linkedUserId: Type.String(),
+  clientId: Type.String(),
+  isAdmin: Type.Boolean(),
+  enabled: Type.Boolean(),
+  createdAt: Type.String(),
+  updatedAt: Type.Union([Type.String(), Type.Null()]),
+  lastRotatedAt: Type.Union([Type.String(), Type.Null()]),
+})
+
+/**
+ * The type for a service account
+ */
+export type ServiceAccount = Static<typeof ServiceAccountSchema>
+
+/**
+ * The schema for a service account response with client secret
+ */
+export const ServiceAccountWithSecretSchema: TObject<{
+  id: TString
+  tenantId: TString
+  name: TString
+  description: TString
+  linkedUserId: TString
+  clientId: TString
+  isAdmin: TBoolean
+  enabled: TBoolean
+  createdAt: TString
+  updatedAt: TUnion<[TString, TNull]>
+  lastRotatedAt: TUnion<[TString, TNull]>
+  clientSecret: TString
+}> = Type.Object({
+  id: Type.String(),
+  tenantId: Type.String(),
+  name: Type.String(),
+  description: Type.String(),
+  linkedUserId: Type.String(),
+  clientId: Type.String(),
+  isAdmin: Type.Boolean(),
+  enabled: Type.Boolean(),
+  createdAt: Type.String(),
+  updatedAt: Type.Union([Type.String(), Type.Null()]),
+  lastRotatedAt: Type.Union([Type.String(), Type.Null()]),
+  clientSecret: Type.String(),
+})
+
+/**
+ * The type for a service account response with client secret
+ */
+export type ServiceAccountWithSecret = Static<typeof ServiceAccountWithSecretSchema>
+
+/**
+ * The schema for a rotated service account secret response
+ */
+export const ServiceAccountSecretRotationSchema: TObject<{
+  id: TString
+  clientId: TString
+  clientSecret: TString
+}> = Type.Object({
+  id: Type.String(),
+  clientId: Type.String(),
+  clientSecret: Type.String(),
+})
+
+/**
+ * The type for a rotated service account secret response
+ */
+export type ServiceAccountSecretRotation = Static<typeof ServiceAccountSecretRotationSchema>

--- a/test/tests/commands/tenant-store.test.ts
+++ b/test/tests/commands/tenant-store.test.ts
@@ -1,0 +1,319 @@
+import { assertEquals, assertRejects } from "@std/assert"
+import { afterAll, afterEach, describe, it } from "@std/testing/bdd"
+import {
+  ApiKeyFetchCommand,
+  ApiKeyValidateCommand,
+  ApiKeyValidateWithTenantIdCommand,
+  FlowcoreClient,
+  NotFoundException,
+  SecretFetchCommand,
+  ServiceAccountCreateCommand,
+  ServiceAccountDeleteCommand,
+  ServiceAccountEditCommand,
+  ServiceAccountFetchCommand,
+  ServiceAccountListCommand,
+  ServiceAccountRotateSecretCommand,
+  VariableFetchCommand,
+} from "../../../src/mod.ts"
+import { FetchMocker } from "../../fixtures/fetch.fixture.ts"
+
+describe("Tenant Store", () => {
+  const fetchMocker = new FetchMocker()
+  const bearerClient = new FlowcoreClient({ getBearerToken: () => "BEARER_TOKEN" })
+  const apiKeyClient = new FlowcoreClient({ apiKey: "fc_keyid_secret" })
+  const fetchMockerBuilder = fetchMocker.mock("https://tenant-store.api.flowcore.io")
+
+  afterEach(() => {
+    fetchMocker.assert()
+  })
+  afterAll(() => fetchMocker.restore())
+
+  it("should fetch an api key", async () => {
+    const apiKey = {
+      id: crypto.randomUUID(),
+      tenantId: crypto.randomUUID(),
+      name: "deploy",
+      description: "deploy key",
+      maskedApiKey: "fc_***",
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+    }
+
+    fetchMockerBuilder.get(`/api/v1/api-keys/${apiKey.id}`).respondWith(200, apiKey)
+
+    const response = await bearerClient.execute(new ApiKeyFetchCommand({ apiKeyId: apiKey.id }))
+
+    assertEquals(response, apiKey)
+  })
+
+  it("should throw not found when api key is missing", async () => {
+    const apiKeyId = crypto.randomUUID()
+    fetchMockerBuilder.get(`/api/v1/api-keys/${apiKeyId}`).respondWith(404, { message: "ApiKey not found" })
+
+    await assertRejects(
+      () => bearerClient.execute(new ApiKeyFetchCommand({ apiKeyId })),
+      NotFoundException,
+      `ApiKey not found: ${JSON.stringify({ id: apiKeyId })}`,
+    )
+  })
+
+  it("should validate an api key", async () => {
+    const responseBody = {
+      valid: true,
+      apiKeyId: crypto.randomUUID(),
+      tenantId: crypto.randomUUID(),
+    }
+
+    fetchMockerBuilder.post("/api/v1/api-keys/validate")
+      .matchBody({ apiKey: "fc_keyid_secret" })
+      .respondWith(200, responseBody)
+
+    const response = await apiKeyClient.execute(new ApiKeyValidateCommand({ apiKey: "fc_keyid_secret" }))
+
+    assertEquals(response, responseBody)
+  })
+
+  it("should validate an api key with tenant id", async () => {
+    const responseBody = {
+      valid: true,
+      apiKeyId: crypto.randomUUID(),
+      tenantId: crypto.randomUUID(),
+    }
+
+    fetchMockerBuilder.post("/api/v1/api-keys/validate-with-tenant-id")
+      .matchBody({
+        apiKey: "legacy-key",
+        tenantId: responseBody.tenantId,
+      })
+      .respondWith(200, responseBody)
+
+    const response = await bearerClient.execute(
+      new ApiKeyValidateWithTenantIdCommand({
+        apiKey: "legacy-key",
+        tenantId: responseBody.tenantId,
+      }),
+    )
+
+    assertEquals(response, responseBody)
+  })
+
+  it("should fetch a secret", async () => {
+    const secret = {
+      tenantId: crypto.randomUUID(),
+      key: "MY_SECRET",
+      description: "secret",
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    }
+
+    fetchMockerBuilder.get(`/api/v1/tenants/${secret.tenantId}/secrets/${secret.key}`).respondWith(200, secret)
+
+    const response = await bearerClient.execute(new SecretFetchCommand({ tenantId: secret.tenantId, key: secret.key }))
+
+    assertEquals(response, secret)
+  })
+
+  it("should throw not found when secret is missing", async () => {
+    const tenantId = crypto.randomUUID()
+    const key = "MISSING_SECRET"
+    fetchMockerBuilder.get(`/api/v1/tenants/${tenantId}/secrets/${key}`).respondWith(404, {
+      message: "Secret not found",
+    })
+
+    await assertRejects(
+      () => bearerClient.execute(new SecretFetchCommand({ tenantId, key })),
+      NotFoundException,
+      `Secret not found: ${JSON.stringify({ tenantId, key })}`,
+    )
+  })
+
+  it("should fetch a variable", async () => {
+    const variable = {
+      tenantId: crypto.randomUUID(),
+      key: "MY_VARIABLE",
+      description: "variable",
+      value: "value",
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    }
+
+    fetchMockerBuilder.get(`/api/v1/tenants/${variable.tenantId}/variables/${variable.key}`).respondWith(200, variable)
+
+    const response = await bearerClient.execute(
+      new VariableFetchCommand({ tenantId: variable.tenantId, key: variable.key }),
+    )
+
+    assertEquals(response, variable)
+  })
+
+  it("should throw not found when variable is missing", async () => {
+    const tenantId = crypto.randomUUID()
+    const key = "MISSING_VARIABLE"
+    fetchMockerBuilder.get(`/api/v1/tenants/${tenantId}/variables/${key}`).respondWith(404, {
+      message: "Variable not found",
+    })
+
+    await assertRejects(
+      () => bearerClient.execute(new VariableFetchCommand({ tenantId, key })),
+      NotFoundException,
+      `Variable not found: ${JSON.stringify({ tenantId, key })}`,
+    )
+  })
+
+  it("should create a service account", async () => {
+    const responseBody = {
+      id: crypto.randomUUID(),
+      tenantId: crypto.randomUUID(),
+      name: "deploy-bot",
+      description: "deploy bot",
+      linkedUserId: crypto.randomUUID(),
+      clientId: "service-account-client",
+      isAdmin: false,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+      lastRotatedAt: null,
+      clientSecret: "secret",
+    }
+
+    fetchMockerBuilder.post("/api/v1/service-accounts")
+      .matchBody({
+        tenantId: responseBody.tenantId,
+        name: responseBody.name,
+        description: responseBody.description,
+        isAdmin: false,
+      })
+      .respondWith(200, responseBody)
+
+    const response = await bearerClient.execute(
+      new ServiceAccountCreateCommand({
+        tenantId: responseBody.tenantId,
+        name: responseBody.name,
+        description: responseBody.description,
+        isAdmin: false,
+      }),
+    )
+
+    assertEquals(response, responseBody)
+  })
+
+  it("should list service accounts", async () => {
+    const tenantId = crypto.randomUUID()
+    const responseBody = [{
+      id: crypto.randomUUID(),
+      tenantId,
+      name: "deploy-bot",
+      description: "",
+      linkedUserId: crypto.randomUUID(),
+      clientId: "service-account-client",
+      isAdmin: false,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+      lastRotatedAt: null,
+    }]
+
+    fetchMockerBuilder.get("/api/v1/service-accounts")
+      .matchSearchParams({ tenantId })
+      .respondWith(200, responseBody)
+
+    const response = await bearerClient.execute(new ServiceAccountListCommand({ tenantId }))
+
+    assertEquals(response, responseBody)
+  })
+
+  it("should fetch a service account", async () => {
+    const serviceAccount = {
+      id: crypto.randomUUID(),
+      tenantId: crypto.randomUUID(),
+      name: "deploy-bot",
+      description: "",
+      linkedUserId: crypto.randomUUID(),
+      clientId: "service-account-client",
+      isAdmin: false,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+      lastRotatedAt: null,
+    }
+
+    fetchMockerBuilder.get(`/api/v1/service-accounts/${serviceAccount.id}`).respondWith(200, serviceAccount)
+
+    const response = await bearerClient.execute(
+      new ServiceAccountFetchCommand({ serviceAccountId: serviceAccount.id }),
+    )
+
+    assertEquals(response, serviceAccount)
+  })
+
+  it("should throw not found when service account is missing", async () => {
+    const serviceAccountId = crypto.randomUUID()
+    fetchMockerBuilder.get(`/api/v1/service-accounts/${serviceAccountId}`).respondWith(404, {
+      message: "ServiceAccount not found",
+    })
+
+    await assertRejects(
+      () => bearerClient.execute(new ServiceAccountFetchCommand({ serviceAccountId })),
+      NotFoundException,
+      `ServiceAccount not found: ${JSON.stringify({ id: serviceAccountId })}`,
+    )
+  })
+
+  it("should edit a service account", async () => {
+    const responseBody = {
+      id: crypto.randomUUID(),
+      tenantId: crypto.randomUUID(),
+      name: "deploy-bot",
+      description: "updated",
+      linkedUserId: crypto.randomUUID(),
+      clientId: "service-account-client",
+      isAdmin: false,
+      enabled: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastRotatedAt: null,
+    }
+
+    fetchMockerBuilder.patch(`/api/v1/service-accounts/${responseBody.id}`)
+      .matchBody({
+        description: responseBody.description,
+        enabled: responseBody.enabled,
+      })
+      .respondWith(200, responseBody)
+
+    const response = await bearerClient.execute(
+      new ServiceAccountEditCommand({
+        serviceAccountId: responseBody.id,
+        description: responseBody.description,
+        enabled: responseBody.enabled,
+      }),
+    )
+
+    assertEquals(response, responseBody)
+  })
+
+  it("should rotate a service account secret", async () => {
+    const responseBody = {
+      id: crypto.randomUUID(),
+      clientId: "service-account-client",
+      clientSecret: "rotated-secret",
+    }
+
+    fetchMockerBuilder.post(`/api/v1/service-accounts/${responseBody.id}/rotate-secret`).respondWith(200, responseBody)
+
+    const response = await bearerClient.execute(
+      new ServiceAccountRotateSecretCommand({ serviceAccountId: responseBody.id }),
+    )
+
+    assertEquals(response, responseBody)
+  })
+
+  it("should delete a service account", async () => {
+    const serviceAccountId = crypto.randomUUID()
+    fetchMockerBuilder.delete(`/api/v1/service-accounts/${serviceAccountId}`).respondWith(200, { success: true })
+
+    const response = await bearerClient.execute(new ServiceAccountDeleteCommand({ serviceAccountId }))
+
+    assertEquals(response, true)
+  })
+})


### PR DESCRIPTION
## What changed
- add missing tenant-store fetch/validate commands for api keys, secrets, and variables
- add service-account contracts and commands for create, fetch, list, update, rotate-secret, and delete
- add tenant-store command tests covering the newly added endpoints

## Why
The tenant-store API added service-account support and already exposed additional fetch/validation endpoints that were not covered by the SDK.

## Impact
Consumers can now manage tenant-store service accounts and use the remaining tenant-store read/validation endpoints through `@flowcore/sdk`.

## Validation
- `deno fmt src/contracts/api-key.ts src/contracts/index.ts src/contracts/service-account.ts src/commands/index.ts src/commands/api-key/api-key.fetch.ts src/commands/api-key/api-key.validate.ts src/commands/api-key/api-key.validate-with-tenant-id.ts src/commands/secret/secret.fetch.ts src/commands/variable/variable.fetch.ts src/commands/service-account/service-account.fetch.ts src/commands/service-account/service-account.list.ts src/commands/service-account/service-account.create.ts src/commands/service-account/service-account.edit.ts src/commands/service-account/service-account.rotate-secret.ts src/commands/service-account/service-account.delete.ts test/tests/commands/tenant-store.test.ts`
- `deno test test/tests/commands/tenant-store.test.ts`
- `deno check src/mod.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added API key management: fetch and validate operations
  - Added secret and variable retrieval by key
  - Expanded service account functionality: create, list, fetch, edit, delete, and credential rotation

* **Tests**
  - Added comprehensive test suite for tenant store operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->