### PR TITLE
feat(data-pathways): source id/name + delivery-log sourceId/eventType

### DIFF
--- a/src/contracts/data-pathways.ts
+++ b/src/contracts/data-pathways.ts
@@ -64,6 +64,8 @@ const TimeoutConfigSchema: TTimeoutConfig = Type.Optional(
 )
 
 type TSourceConfig = TObject<{
+  id: TOptional<TString>
+  name: TOptional<TString>
   flowType: TString
   eventTypes: TArray<TString>
   endpoints: TArray<TEndpointConfig>
@@ -73,6 +75,8 @@ type TSourceConfig = TObject<{
   timeouts: TTimeoutConfig
 }>
 const SourceConfigSchema: TSourceConfig = Type.Object({
+  id: Type.Optional(Type.String()),
+  name: Type.Optional(Type.String()),
   flowType: Type.String(),
   eventTypes: Type.Array(Type.String()),
   endpoints: Type.Array(EndpointConfigSchema),
@@ -530,6 +534,8 @@ export const DataPathwayDeliveryLogEntrySchema: TObject<{
   errorMessage: TUnion<[TString, TNull]>
   responseBody: TUnion<[TString, TNull]>
   flowType: TUnion<[TString, TNull]>
+  sourceId: TUnion<[TString, TNull]>
+  eventType: TUnion<[TString, TNull]>
   createdAt: TString
 }> = Type.Object({
   id: Type.String(),
@@ -543,6 +549,8 @@ export const DataPathwayDeliveryLogEntrySchema: TObject<{
   errorMessage: Type.Union([Type.String(), Type.Null()]),
   responseBody: Type.Union([Type.String(), Type.Null()]),
   flowType: Type.Union([Type.String(), Type.Null()]),
+  sourceId: Type.Union([Type.String(), Type.Null()]),
+  eventType: Type.Union([Type.String(), Type.Null()]),
   createdAt: Type.String(),
 })
 export type DataPathwayDeliveryLogEntry = Static<typeof DataPathwayDeliveryLogEntrySchema>
@@ -561,6 +569,8 @@ export const DataPathwayDeliveryLogBatchEntrySchema: TObject<{
   assignmentId: TString
   endpointUrl: TString
   flowType: TOptional<TString>
+  sourceId: TOptional<TString>
+  eventType: TOptional<TString>
   httpStatus: TOptional<TInteger>
   success: TBoolean
   batchSize: TOptional<TInteger>
@@ -572,6 +582,8 @@ export const DataPathwayDeliveryLogBatchEntrySchema: TObject<{
   assignmentId: Type.String(),
   endpointUrl: Type.String(),
   flowType: Type.Optional(Type.String()),
+  sourceId: Type.Optional(Type.String()),
+  eventType: Type.Optional(Type.String()),
   httpStatus: Type.Optional(Type.Integer()),
   success: Type.Boolean(),
   batchSize: Type.Optional(Type.Integer()),

--- a/test/tests/commands/data-pathways.test.ts
+++ b/test/tests/commands/data-pathways.test.ts
@@ -782,4 +782,29 @@ describe("DataPathways", () => {
     )
     assertEquals(result, response)
   })
+
+  it("should accept sourceId and eventType on delivery log batch entries", async () => {
+    const pathwayId = crypto.randomUUID()
+    const assignmentId = crypto.randomUUID()
+    const sourceId = crypto.randomUUID()
+    const response = { inserted: 1 }
+
+    base.post("/api/v1/delivery-log/batch")
+      .respondWith(200, response)
+
+    const result = await apiKeyClient.execute(
+      new DataPathwayDeliveryLogBatchCommand({
+        entries: [{
+          pathwayId,
+          assignmentId,
+          endpointUrl: "https://example.com/webhook",
+          success: true,
+          flowType: "analytics",
+          sourceId,
+          eventType: "pat.created.0",
+        }],
+      }),
+    )
+    assertEquals(result, response)
+  })
 })


### PR DESCRIPTION
## Summary

- `SourceConfigSchema` gets optional `id` + `name` so callers can address and label pathway sources that share a flowType.
- `DataPathwayDeliveryLogEntrySchema` adds nullable `sourceId` + `eventType`.
- `DataPathwayDeliveryLogBatchEntrySchema` accepts the two new fields on POST.

Mirrors the additive Phase 1 contract landed in data-pathways v2.6.0. Phase 2 will swap pump_states uniqueness to be id-keyed and add sourceId-addressed pump-state commands; this SDK change lands the additive surface first so consumers can start reading the new fields.

## Test plan

- [x] `deno test --allow-all test/tests/commands/data-pathways.test.ts` green (new case: `should accept sourceId and eventType on delivery log batch entries`)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data sources now support optional identifiers and names; delivery logs can track source identification and event type information for enhanced data monitoring.

* **Tests**
  * Added tests for delivery-log batch commands with new metadata field support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->