### PR TITLE
feat(data-pathways): add optional sourceId to SendPumpPulseCommand

### DIFF
--- a/src/commands/data-pathways/pump-pulse.send.ts
+++ b/src/commands/data-pathways/pump-pulse.send.ts
@@ -4,6 +4,7 @@ import { type DataPathwayPumpPulseResponse, DataPathwayPumpPulseResponseSchema }
 
 export interface SendPumpPulseInput {
   pathwayId: string
+  sourceId?: string
   flowType: string
   timeBucket: string
   eventId: string | null


### PR DESCRIPTION
## Summary
- Add optional `sourceId?: string` to `SendPumpPulseInput`
- Additive / non-breaking — callers that don't set it are unaffected

## Why
The data-pathways control-plane accepts `sourceId` in its `/api/v1/pump-pulse` route's Zod schema but the SDK input type never exposed it. Downstream (`@flowcore/data-pump`'s `PulseEmitter`) therefore can't thread per-source identity into pulses. Result: every pulse lands on a single NULL-sourceId row per flowType in `pump_pulses`, shadowing any correctly-keyed sibling.

This is the first of three PRs; the matching changes live in `@flowcore/data-pump` (new `pulse.sourceId` option) and the data-pathways worker (pass `source.id` into `buildPump`).

## Test plan
- [x] `deno check src/mod.ts` clean
- [ ] Reviewer confirms release-please bumps as patch (`3.3.0` → `3.3.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal data handling capabilities by introducing an optional identifier parameter, enabling improved data pathway functionality without affecting existing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->