### PR TITLE
fix: demote websocket lifecycle logs

### DIFF
--- a/src/common/notification-client.ts
+++ b/src/common/notification-client.ts
@@ -190,7 +190,7 @@ export class NotificationClient {
     this.webSocket.onopen = () => {
       this._isOpen = true
       this._isConnecting = false
-      this.logger.info("WebSocket connection opened.")
+      this.logger.debug("WebSocket connection opened.")
       this.reconnectInterval = this.options.reconnectInterval
       this.reconnectAttempts = 0
       this.webSocket.send(
@@ -253,7 +253,7 @@ export class NotificationClient {
 
     this.webSocket.onclose = (event) => {
       this._isOpen = false
-      this.logger.info(`Connection closed: Code [${event.code}], Reason: ${event.reason}`)
+      this.logger.debug(`Connection closed: Code [${event.code}], Reason: ${event.reason}`)
       if (![1000].includes(event.code)) {
         this.attemptReconnect()
         return

--- a/src/common/websocket-client.ts
+++ b/src/common/websocket-client.ts
@@ -121,7 +121,7 @@ export class WebSocketClient {
     command: WebSocketCommand<Config, SendPayload>,
   ): Promise<ActiveStreamInterface<SendPayload>> {
     if (this._isConnecting || this._isOpen) {
-      this.logger.info("Disconnecting existing stream before starting new one.")
+      this.logger.debug("Disconnecting existing stream before starting new one.")
       this.disconnect() // Ensure clean state
       // Add a small delay to allow disconnect process to settle if needed
       await new Promise((resolve) => setTimeout(resolve, 50))
@@ -135,7 +135,7 @@ export class WebSocketClient {
     // Use override URL if set, otherwise use command's base URL
     const baseUrl = this.overrideBaseUrl ?? command.getWebSocketBaseUrl()
     const pathSegment = command.getWebSocketPathSegment(config) // Get path segment from command
-    this.logger.info(`Attempting to connect stream: ${baseUrl}${pathSegment}`)
+    this.logger.debug(`Attempting to connect stream: ${baseUrl}${pathSegment}`)
 
     try {
       const urlParams = new URLSearchParams()
@@ -189,7 +189,7 @@ export class WebSocketClient {
       const logUrl = baseUrl && pathSegment
         ? `${baseUrl.replace(/\/?$/, "/")}${pathSegment.replace(/^\/?/, "")}`
         : "(unknown URL)"
-      this.logger.info(`WebSocket connection opened: ${logUrl}`)
+      this.logger.debug(`WebSocket connection opened: ${logUrl}`)
       this.reconnectInterval = this.options.reconnectInterval
       this.reconnectAttempts = 0
     }
@@ -233,14 +233,14 @@ export class WebSocketClient {
       const logUrl = baseUrl && pathSegment
         ? `${baseUrl.replace(/\/?$/, "/")}${pathSegment.replace(/^\/?/, "")}`
         : "(unknown URL)"
-      this.logger.info(
+      this.logger.debug(
         `WebSocket connection closed: ${logUrl} Code [${event.code}], Reason: ${event.reason || "No reason given"}
 . Was open: ${wasOpen}`,
       )
       if (wasOpen && event.code !== 1000 && this.currentCommand) { // Only reconnect if command is still set
         this.attemptReconnect()
       } else {
-        this.logger.info(`Completing internal subject due to close event.`)
+        this.logger.debug(`Completing internal subject due to close event.`)
         this.internalSubject.complete() // Complete subject on final close
         this.currentCommand = null // Clear state
         this.currentConfig = null
@@ -310,7 +310,7 @@ export class WebSocketClient {
     setTimeout(async () => { // Keep timeout async
       // Check if disconnect was called while waiting
       if (!this.currentCommand || !this.currentConfig) {
-        this.logger.info("Reconnect cancelled as disconnect was called.")
+        this.logger.debug("Reconnect cancelled as disconnect was called.")
         this._isConnecting = false // Ensure flag is reset
         if (!this.internalSubject.closed) this.internalSubject.complete()
         return
@@ -379,7 +379,7 @@ export class WebSocketClient {
    * Closes the WebSocket connection gracefully.
    */
   disconnect() {
-    this.logger.info("Disconnect called by user.")
+    this.logger.debug("Disconnect called by user.")
     const commandToClear = this.currentCommand // Store ref before clearing
     this.currentCommand = null // Prevent reconnects
     this.currentConfig = null
@@ -398,7 +398,7 @@ export class WebSocketClient {
 
     // Complete the subject if it hasn't been completed by onclose
     if (commandToClear && !this.internalSubject.closed) {
-      this.logger.info("Completing internal subject due to disconnect call.")
+      this.logger.debug("Completing internal subject due to disconnect call.")
       this.internalSubject.complete()
     }
   }

--- a/test/tests/common/websocket-client.test.ts
+++ b/test/tests/common/websocket-client.test.ts
@@ -15,7 +15,7 @@ import {
   WebSocketClient, // Renamed client
   type WebSocketClientOptions,
 } from "../../../src/mod.ts"
-import { defaultLogger } from "../../../src/utils/logger.ts"
+import { defaultLogger, type Logger } from "../../../src/utils/logger.ts"
 
 // --- Mock WebSocket Definition (MinimalWebSocket) ---
 interface MockMinimalWebSocket {
@@ -34,6 +34,22 @@ interface MockMinimalWebSocket {
 }
 
 let mockWebSocketInstances: MockMinimalWebSocket[] = []
+
+function createRecordingLogger(): Logger & { calls: Record<keyof Logger, string[]> } {
+  const calls: Record<keyof Logger, string[]> = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+  }
+  return {
+    calls,
+    debug: (message) => calls.debug.push(message),
+    info: (message) => calls.info.push(message),
+    warn: (message) => calls.warn.push(message),
+    error: (message) => calls.error.push(String(message)),
+  }
+}
 
 function mockWebSocketFactory(url: string): MockMinimalWebSocket {
   const instance: MockMinimalWebSocket = {
@@ -250,6 +266,37 @@ describe("WebSocketClient", () => { // Updated describe block
 
     assertEquals(client.isOpen, false)
     assertEquals(completed, true)
+  })
+
+  it("normal connection lifecycle logs should use debug, not info", async () => {
+    const logger = createRecordingLogger()
+    client = createClient(authOptionsBearer, { logger })
+    activeStream = await client.connect(testCommand)
+    assertExists(activeStream, "activeStream should be defined after connect")
+    assertExists(mockWebSocketInstances[0])
+
+    mockWebSocketInstances[0]._triggerOpen()
+    await delay(0)
+    mockWebSocketInstances[0]._triggerClose(1000, "Normal closure")
+    await delay(10)
+
+    assertEquals(
+      logger.calls.debug.some((message) => message.startsWith("Attempting to connect stream:")),
+      true,
+    )
+    assertEquals(
+      logger.calls.debug.some((message) => message.startsWith("WebSocket connection opened:")),
+      true,
+    )
+    assertEquals(
+      logger.calls.debug.some((message) => message.startsWith("WebSocket connection closed:")),
+      true,
+    )
+    assertEquals(
+      logger.calls.debug.includes("Completing internal subject due to close event."),
+      true,
+    )
+    assertEquals(logger.calls.info.length, 0)
   })
 
   it("should attempt reconnect on unexpected close and succeed", async () => {


### PR DESCRIPTION
## Summary
- demote normal SDK websocket open/close lifecycle logs to debug
- keep reconnect and error signals visible
- add regression coverage for lifecycle log levels

## Test plan
- deno fmt --check src/common/notification-client.ts src/common/websocket-client.ts test/tests/common/websocket-client.test.ts
- deno test -A test/tests/common/websocket-client.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted WebSocket connection lifecycle event logging to debug-level verbosity, reducing operational log volume during normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->