### PR TITLE
fix: run bun validation after main merges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build and Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,10 @@
 name: Test
 
 on:
+  pull_request:
   push:
-    branches-ignore: ["main"]
+    branches: ["main"]
+  workflow_dispatch:
 
 env:
   BUN_VERSION: "1.3.14"


### PR DESCRIPTION
## Summary

- run the Bun validation workflow on pull requests and pushes to `main`
- keep a manual `workflow_dispatch` escape hatch for validation
- add manual dispatch to the npm publish workflow so publish can be triggered deliberately when release-please does not create a release

## Root Cause

PR #227 merged successfully, but only `release-please` ran on `main`. The validation workflow ignored `main`, and npm publish only runs on `release.published`. Release-please skipped release creation because the merge commit was `chore: ...` and it logged `No user facing commits found... skipping`.

## Validation

- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration to support manual build triggering and improve validation coverage on pull requests and the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->