### PR TITLE
chore(ci): disable npm provenance on self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish to NPM
-        run: npm publish --access public
+        run: npm publish --access public --provenance=false


### PR DESCRIPTION
## Summary

- restore explicit `--provenance=false` on `npm publish`
- required because this workflow runs on Blacksmith/self-hosted runners

## Root Cause

`npm publish --access public` now auto-signed provenance in this workflow because `id-token: write` is available. npm rejected the publish with:

`Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.`

## Validation

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 204 passing
- `bun run build`
- `bunx npm@latest pack --dry-run` — `@flowcore/sdk@4.2.3`