### PR TITLE
chore(ci): align npm publish permissions with blacksmith

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary

- align npm publish workflow with the Usable Blacksmith publishing pattern
- remove `id-token: write` from publish workflow permissions
- keep `npm publish --access public --provenance=false`

## Usable grounding

Fragment: `d474dd0d-470d-49cc-9bab-db3002e06e5a` — `Trusted Publishing for flowcore-io npm Packages with Bun`

The Flowcore Blacksmith pattern is:

- `permissions.contents: read`
- `useblacksmith/setup-node`
- no `NODE_AUTH_TOKEN` / `NPM_TOKEN`
- `npm publish --access public --provenance=false`

## Validation

- YAML parse check for `.github/workflows/build.yml`
- confirmed publish workflow has no `id-token`, no npm token env, and keeps provenance disabled