### PR TITLE
fix(ci): restore NODE_AUTH_TOKEN on npm publish step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,5 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish --access public --provenance=false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The Blacksmith migration (13f567b) dropped `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the Publish-to-NPM step, so `npm publish` ran unauthenticated and 404'd on every release since — **4.2.3 and 4.2.4 never reached npm**. Restoring the env so the publish authenticates again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)