### PR TITLE
fix(ci): use OIDC id-token for npm publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:


### PR DESCRIPTION
The Blacksmith no-OIDC npm-auth path stopped working — `npm publish` 404'd (unauthenticated PUT) for 4.2.3 and 4.2.4, so neither reached npm. Adding `id-token: write` switches to npm **Trusted Publisher OIDC** (still token-free). Verified on a branch dispatch: auth succeeded (got past auth to the 'cannot publish over 4.2.3' version check). Provenance stays `--provenance=false` (self-hosted Blacksmith runner). After merge I'll re-run the publish to ship 4.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)