### PR TITLE
feat(api-key): allow apiKey mode on api-key management commands

### DIFF
--- a/src/commands/api-key/api-key.create.ts
+++ b/src/commands/api-key/api-key.create.ts
@@ -44,9 +44,11 @@ export class ApiKeyCreateCommand extends Command<ApiKeyCreateInput, ApiKeyWithVa
   }
 
   /**
-   * The allowed modes for the command
+   * The allowed modes for the command. Api-key mode requires tenant-store >=
+   * the release that accepts AuthType.ApiKey on the api-key management routes;
+   * authorization is still gated by IAM grants on frn::<tenantId>:tenant.
    */
-  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["apiKey", "bearer"]
 
   /**
    * Parse the response

--- a/src/commands/api-key/api-key.delete.ts
+++ b/src/commands/api-key/api-key.delete.ts
@@ -38,9 +38,11 @@ export class ApiKeyDeleteCommand extends Command<ApiKeyDeleteInput, boolean> {
   }
 
   /**
-   * The allowed modes for the command
+   * The allowed modes for the command. Api-key mode requires tenant-store >=
+   * the release that accepts AuthType.ApiKey on the api-key management routes;
+   * authorization is still gated by IAM grants on frn::<tenantId>:tenant.
    */
-  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["apiKey", "bearer"]
 
   /**
    * Parse the response

--- a/src/commands/api-key/api-key.edit.ts
+++ b/src/commands/api-key/api-key.edit.ts
@@ -42,9 +42,11 @@ export class ApiKeyEditCommand extends Command<ApiKeyEditInput, ApiKey> {
   }
 
   /**
-   * The allowed modes for the command
+   * The allowed modes for the command. Api-key mode requires tenant-store >=
+   * the release that accepts AuthType.ApiKey on the api-key management routes;
+   * authorization is still gated by IAM grants on frn::<tenantId>:tenant.
    */
-  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["apiKey", "bearer"]
 
   /**
    * Parse the response

--- a/src/commands/api-key/api-key.fetch.ts
+++ b/src/commands/api-key/api-key.fetch.ts
@@ -43,9 +43,11 @@ export class ApiKeyFetchCommand extends Command<ApiKeyFetchInput, ApiKey> {
   }
 
   /**
-   * The allowed modes for the command
+   * The allowed modes for the command. Api-key mode requires tenant-store >=
+   * the release that accepts AuthType.ApiKey on the api-key management routes;
+   * authorization is still gated by IAM grants on frn::<tenantId>:tenant.
    */
-  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["apiKey", "bearer"]
 
   /**
    * Parse the response

--- a/src/commands/api-key/api-key.list.ts
+++ b/src/commands/api-key/api-key.list.ts
@@ -41,9 +41,11 @@ export class ApiKeyListCommand extends Command<ApiKeyListInput, ApiKey[]> {
   }
 
   /**
-   * The allowed modes for the command
+   * The allowed modes for the command. Api-key mode requires tenant-store >=
+   * the release that accepts AuthType.ApiKey on the api-key management routes;
+   * authorization is still gated by IAM grants on frn::<tenantId>:tenant.
    */
-  protected override allowedModes: ("apiKey" | "bearer")[] = ["bearer"]
+  protected override allowedModes: ("apiKey" | "bearer")[] = ["apiKey", "bearer"]
 
   /**
    * Parse the response


### PR DESCRIPTION
## Problem

`ApiKeyListCommand`, `ApiKeyFetchCommand`, `ApiKeyCreateCommand`, `ApiKeyEditCommand`, and `ApiKeyDeleteCommand` declare `allowedModes: ["bearer"]`, so a `FlowcoreClient` authenticated with an api key throws `Not allowed in "apiKey" mode` client-side before any request is made. This blocks api-key-driven IAM automation (e.g. listing keys to link policies to them).

## Change

Relax `allowedModes` to `["apiKey", "bearer"]` on the five api-key management commands. Server-side authorization is unchanged and mandatory: tenant-store gates these routes on IAM grants (`frn::<tenantId>:tenant` read/write), and api-key principals never get the flowcore-admin bypass.

## Dependencies — merge order

Requires the tenant-store release that accepts `AuthType.ApiKey` on the api-key management routes (flowcore-io/service-tenant-store-api, `feat/api-key-auth-on-api-key-routes`, built on @flowcore/hono-api 0.4.0). **Hold merge until that is deployed** — otherwise clients get server-side 401s instead of the clear client-side mode error.

Part of the fc_ api-key enablement series: flowcore-io/service-iam-service#89 (deployed, v1.34.0), flowcore-io/hono-api#37 (v0.4.0), tenant-store PR (pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmTkzbSACo6PhBj9o1Sr8A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key management actions now support both API key and bearer authentication modes.
  * Create, view, edit, list, and delete flows can work with newer API key authorization paths where available.
  * Existing bearer-based access remains supported, with authorization restrictions unchanged where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->